### PR TITLE
following the community-standard practices even further!

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,16 +201,12 @@ endif
 # targets help respect (evolving) best practices.
 
 # inspired from http://adam.chlipala.net/cpdt/html/Large.html "Build Process"
-MODULES := DeBruijn DblibTactics Environments
-VS      := $(MODULES:%=%.v)
-LIBRARY_NAME := Dblib # installation will go to user-contrib/$(LIBRARY_NAME)...
-
-Makefile.coq_makefile: Makefile $(VS)
-	coq_makefile -R . $(LIBRARY_NAME) $(VS) -o Makefile.coq_makefile
+Makefile.coq_makefile: Makefile
+	coq_makefile -f _CoqProject -o Makefile.coq_makefile
 
 clean:: Makefile.coq_makefile
 	$(MAKE) -f Makefile.coq_makefile clean
 	rm -f Makefile.coq
 
 install: Makefile.coq_makefile
-	$(MAKE) -f Makefile.coq_makefile install
+	$(MAKE) -f Makefile.coq_makefile all install

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,0 +1,4 @@
+-R . Dblib
+DeBruijn.v
+DblibTactics.v
+Environments.v


### PR DESCRIPTION
After a discussion with Pierre Courtieu, using a _CoqProject file
seems to be the future of Coq packaging.

Note the addition of Makefile.coq_makefile's "all" target to the
install step. It will re-compile the to-be-installed .v files in
a coq_makefile-controlled way, which adds the right "-R . Dblib"
parameter at compilation-time that will allow Dblib to be actually
usable as an external library (without them, Coq may complain about
disagreement between logical and physical path, or something like
this).