### PR TITLE
Lemma concat_app: concat e1 (e2 ++ e3) = concat (concat e1 e2) e3.

### DIFF
--- a/Environments.v
+++ b/Environments.v
@@ -1131,6 +1131,14 @@ Proof.
   eauto with f_equal omega.
 Qed.
 
+Lemma concat_app:
+  forall (A : Type) e1 (e2 e3 : list A),
+    concat e1 (e2 ++ e3) = concat (concat e1 e2) e3.
+Proof.
+  intros A e1 e2 e3. generalize e1. clear e1.
+  induction e2; intro e1; simpl; auto.
+Qed.
+
 (* [replicate n a] is a list of [n] elements, all of which are
    equal to [a]. *)
 


### PR DESCRIPTION
In my proofs I manipulate lists where the new variables are consed onto the list (which thus has the newest variables at the top, the oldest at the bottom). I therefore use `concat e (rev li)` to preserve the binding order; when reasoning by induction on `li` in such cases, `rev (x :: xs)` reduces to `rev xs ++ (x :: nil)`, and being able to rewrite with `concat_app` is handy.